### PR TITLE
Use sbt-projectmatrix instead of sbt-crossproject to fix Stryker4s

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -40,19 +40,17 @@ jobs:
       - name: Test
         run: sbt test
   mutation-testing:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - name: Run stryker
-      run: |
-        echo 'stryker4s{reporters=["console","dashboard"]}' > stryker4s.conf
-        sbt 'project WeaponRegeXJVM; stryker'
-      env:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Run stryker
+        run: |
+          echo 'stryker4s{reporters=["console","dashboard"]}' > stryker4s.conf
+          sbt 'project WeaponRegeX; stryker'
+        env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
-

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,9 @@
-ThisBuild / scalaVersion := "2.13.3"
-ThisBuild / version := "0.1-SNAPSHOT"
-
 // Skip publish root
 skip in publish := true
 
 inThisBuild(
   List(
+    version := "0.1-SNAPSHOT",
     organization := "io.stryker-mutator",
     homepage := Some(url("https://github.com/Nhaajt/Weapon-regeX")),
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
@@ -13,10 +11,9 @@ inThisBuild(
   )
 )
 
-lazy val WeaponRegeX = crossProject(JVMPlatform, JSPlatform)
-  .in(file("."))
+lazy val WeaponRegeX = projectMatrix
+  .in(file("shared"))
   .settings(
-    crossScalaVersions := List("2.13.3", "2.12.12"),
     name := "weapon-regex",
     // libraryDependencies += "com.lihaoyi" %%% "pprint" % "0.6.0",
     // libraryDependencies += "com.kyleu" %% "reftree" % "1.4.1", // Unofficial fork that works with Scala 2.13
@@ -24,11 +21,17 @@ lazy val WeaponRegeX = crossProject(JVMPlatform, JSPlatform)
     libraryDependencies += "org.scalameta" %%% "munit" % "0.7.16" % Test,
     testFrameworks += new TestFramework("munit.Framework")
   )
-  .jvmSettings(
-    // Add JVM-specific settings here
-    libraryDependencies += "org.scala-js" %% "scalajs-stubs" % "1.0.0" % "provided"
+  .jvmPlatform(
+    scalaVersions = List("2.13.3", "2.12.12"),
+    settings = Seq(
+      // Add JVM-specific settings here
+      libraryDependencies += "org.scala-js" %% "scalajs-stubs" % "1.0.0" % "provided"
+    )
   )
-  .jsSettings(
-    // Add JS-specific settings here
-    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
+  .jsPlatform(
+    scalaVersions = List("2.13.3", "2.12.12"),
+    settings = Seq(
+      // Add JS-specific settings here
+      scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
+    )
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.0")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.6.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("io.stryker-mutator" % "sbt-stryker4s" % "0.10.0-RC3")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.4")


### PR DESCRIPTION
Sbt-crossproject doesn't work with Stryker4s for unknown reasons 🤷‍♀️. It will always report a mutation score of 0%. Luckily there's an alternative: [sbt-projectmatrix](https://github.com/sbt/sbt-projectmatrix/). The setup is mostly the same, except for the project names:

```
❯ sbt projects
[info] In file:/home/hugovr/ws/Weapon-regeX/
[info]     WeaponRegeX
[info]     WeaponRegeX2_12
[info]     WeaponRegeXJS
[info]     WeaponRegeXJS2_12
[info]   * weapon-regex
```
