### PR TITLE
feat(error handling): Add error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ With Weapon regeX you can mutate regular expressions which can be used in mutati
 generated regular expressions cover edge cases and typos. Weapon regeX is available for both
 Javascript and Scala. The Javascript version of the library is generated from Scala using [ScalaJS](https://www.scala-js.org/).
 
-The current supported versions for Scala are: 2.12.12 and 2.13.3.
+The current supported versions for Scala are: `2.12.12` and `2.13.3`.
 
 # Getting started
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Weapon regeX
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FNhaajt%2FWeapon-regeX%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/Nhaajt/Weapon-regeX/main)
 [![Build Status](https://github.com/Nhaajt/Weapon-regeX/workflows/Scala%20CI/badge.svg)](https://github.com/Nhaajt/Weapon-regeX/actions?query=workflow%3AScala%20CI+branch%3Amain)
+[<img src="https://img.shields.io/badge/GitHub Pages-🌐-blue" alt="GitHub Pages">](https://nhaajt.github.io/Weapon-regeX/)
 
 <img src="images/WeaponRegeX_logo.svg" width="50%" alt="Weapon regeX Logo">
 
@@ -14,23 +15,25 @@ The current supported versions for Scala are: 2.12.12 and 2.13.3.
 
 ## Scala
 Add Weapon regeX to your ```build.sbt```.
-```Scala
+```scala
 "io.stryker-mutator" %% "weapon-regex" % "0.1.2"
 ```
 
 Mutate!
 
-```Scala
+```scala
 import weaponregex.WeaponRegeX
+import scala.util.{Success, Failure}
 
-val mutants = WeaponRegeX.mutate("^abc(d+|[xyz])$")
-
-mutants.map(mutant => println(mutant.pattern))
+WeaponRegeX.mutate("^abc(d+|[xyz])$") match {
+  case Success(mutants) => mutants map (_.pattern) map println
+  case Failure(e)       => print(e.getMessage)
+}
 ```
 
 ## Javascript
 
-Install Weapon regeX with npm.
+Install Weapon regeX with `npm`.
 
 ```bash
 npm install weapon-regex
@@ -38,10 +41,10 @@ npm install weapon-regex
 
 Mutate!
 
-```Javascript
+```javascript
 const wrx = require('weapon-regex');
 
-var mutants = wrx.mutate("^abc(d+|[xyz])$");
+let mutants = wrx.mutate("^abc(d+|[xyz])$");
 
 mutants.forEach(mutant => {
   console.log(mutant.pattern);
@@ -54,11 +57,13 @@ mutants.forEach(mutant => {
 The ```mutate``` function has the following signature:
 
 ```scala
+//import scala.util.{Try, Success, Failure}
+
 def mutate(
       pattern: String,
       mutators: Seq[TokenMutator] = BuiltinMutators.all,
       mutationLevels: Seq[Int] = null
-  ): Seq[Mutant]
+  ): Try[Seq[Mutant]]
 ```
 With the ```mutators``` argument you can give a select list of mutators that should be used in
 the mutation process. If omitted, all builtin mutators will be used. This list will be filtered
@@ -66,6 +71,8 @@ depending on the ```mutationLevels``` argument.
 
 A list of ```mutationLevels``` can also be passed to the function. The mutators will be filtered
 based on the levels in the list. If omitted, no filtering takes place.
+
+This function will return a `Success` of of a sequence of `Mutant` if can be parsed, a `Failure` otherwise.
 
 ## Javascript
 
@@ -75,7 +82,7 @@ used in the mutation process:
 ```Javascript
 const wrx = require('weapon-regex');
 
-val mutants = wrx.mutate("^abc(d+|[xyz])$",{
+let mutants = wrx.mutate("^abc(d+|[xyz])$",{
   mutators: Array.from(wrx.mutators.values()),
   mutationLevels: [1, 2, 3]
 });
@@ -84,6 +91,8 @@ val mutants = wrx.mutate("^abc(d+|[xyz])$",{
 Both options can be omitted, and have the same functionality as the options described in the Scala
 API section. You can get a map of mutators from the ```mutators``` attribute of the library. It is
 a map from string (mutator name) to a mutator object.
+
+This function will return a JavaScript Array of `Mutant` if can be parsed, or throw an exception otherwise.
 
 # Supported mutators
 All the supported mutators and at which mutation level they appear are shown in the table below.

--- a/core/src/main/scala/weaponregex/WeaponRegeX.scala
+++ b/core/src/main/scala/weaponregex/WeaponRegeX.scala
@@ -6,6 +6,7 @@ import weaponregex.model.mutation._
 import weaponregex.mutator.BuiltinMutators
 
 import scala.scalajs.js.annotation._
+import scala.util.Try
 
 /** The API facade of Weapon regeX for Scala/JVM
   */
@@ -17,15 +18,11 @@ object WeaponRegeX {
     * @param pattern Input regex string
     * @param mutators Mutators to be used for mutation
     * @param mutationLevels Target mutation levels. If this is `null`, the `mutators` will not be filtered.
-    * @return A sequence of [[weaponregex.model.mutation.Mutant]]
+    * @return A `Success` of a sequence of [[weaponregex.model.mutation.Mutant]] if can be parsed, a `Failure` otherwise
     */
   def mutate(
       pattern: String,
       mutators: Seq[TokenMutator] = BuiltinMutators.all,
       mutationLevels: Seq[Int] = null
-  ): Seq[Mutant] =
-    Parser(pattern) match {
-      case Some(tree) => tree.mutate(mutators, mutationLevels)
-      case None       => Nil
-    }
+  ): Try[Seq[Mutant]] = Parser(pattern) map (_.mutate(mutators, mutationLevels))
 }

--- a/core/src/main/scala/weaponregex/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/parser/Parser.scala
@@ -369,8 +369,8 @@ class Parser private (val pattern: String) {
   def RE[_: P]: P[RegexTree] = P(or | simpleRE)
 
   /** The entry point of the parser that should parse from the start to the end of the regex string
-   * @return [[weaponregex.model.regextree.RegexTree]] tree
-   */
+    * @return [[weaponregex.model.regextree.RegexTree]] tree
+    */
   def entry[_: P]: P[RegexTree] = P(Start ~ RE ~ End)
 
   /** Parse the given regex pattern

--- a/core/src/main/scala/weaponregex/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/parser/Parser.scala
@@ -368,10 +368,15 @@ class Parser private (val pattern: String) {
     */
   def RE[_: P]: P[RegexTree] = P(or | simpleRE)
 
+  /** The entry point of the parser that should parse from the start to the end of the regex string
+   * @return [[weaponregex.model.regextree.RegexTree]] tree
+   */
+  def entry[_: P]: P[RegexTree] = P(Start ~ RE ~ End)
+
   /** Parse the given regex pattern
     * @return A `Success` of parsed [[weaponregex.model.regextree.RegexTree]] if can be parsed, a `Failure` otherwise
     */
-  def parse: Try[RegexTree] = fastparse.parse(pattern, RE(_)) match {
+  def parse: Try[RegexTree] = fastparse.parse(pattern, entry(_)) match {
     case Parsed.Success(regexTree: RegexTree, index) => Success(regexTree)
     case f @ Parsed.Failure(str, index, extra)       => Failure(new RuntimeException("[Error] Parser: " + f.msg))
   }

--- a/core/src/main/scala/weaponregex/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/parser/Parser.scala
@@ -1,9 +1,12 @@
 package weaponregex.parser
 
-import fastparse._, NoWhitespace._
+import fastparse._
+import NoWhitespace._
 import weaponregex.model._
 import weaponregex.model.regextree._
 import weaponregex.extension.StringExtension.StringIndexExtension
+
+import scala.util.{Failure, Success, Try}
 
 /** Companion object for [[weaponregex.parser.Parser]] class that instantiates [[weaponregex.parser.Parser]] instances
   */
@@ -11,16 +14,9 @@ object Parser {
 
   /** Apply the parser to parse the given pattern
     * @param pattern The regex pattern to be parsed
-    * @return An `Option`al parsed [[weaponregex.model.regextree.RegexTree]]
+    * @return A `Success` of parsed [[weaponregex.model.regextree.RegexTree]] if can be parsed, a `Failure` otherwise
     */
-  def apply(pattern: String): Option[RegexTree] = new Parser(pattern).parse
-
-  /** Apply the parser to parse the given pattern
-    * @param pattern The regex pattern to be parsed
-    * @return [[weaponregex.model.regextree.RegexTree]] if the given pattern can ber parsed, throw an error otherwise
-    */
-  def parseOrError(pattern: String): RegexTree =
-    new Parser(pattern).parse.getOrElse(throw new RuntimeException("Failed to parse regex"))
+  def apply(pattern: String): Try[RegexTree] = new Parser(pattern).parse
 }
 
 /** @param pattern The regex pattern to be parsed
@@ -373,10 +369,10 @@ class Parser private (val pattern: String) {
   def RE[_: P]: P[RegexTree] = P(or | simpleRE)
 
   /** Parse the given regex pattern
-    * @return An `Option`al parsed [[weaponregex.model.regextree.RegexTree]]
+    * @return A `Success` of parsed [[weaponregex.model.regextree.RegexTree]] if can be parsed, a `Failure` otherwise
     */
-  def parse: Option[RegexTree] = fastparse.parse(pattern, RE(_)) match {
-    case Parsed.Success(regexTree: RegexTree, index) => Some(regexTree)
-    case Parsed.Failure(str, index, extra)           => None
+  def parse: Try[RegexTree] = fastparse.parse(pattern, RE(_)) match {
+    case Parsed.Success(regexTree: RegexTree, index) => Success(regexTree)
+    case f @ Parsed.Failure(str, index, extra)       => Failure(new RuntimeException("[Error] Parser: " + f.msg))
   }
 }

--- a/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
+++ b/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
@@ -53,8 +53,8 @@ object WeaponRegeXJS {
       else null
 
     Parser(pattern) match {
-      case Success(tree)                        => (tree.mutate(mutators, mutationLevels) map MutantJS).toJSArray
-      case Failure(exception: RuntimeException) => throw exception
+      case Success(tree)                 => (tree.mutate(mutators, mutationLevels) map MutantJS).toJSArray
+      case Failure(throwable: Throwable) => throw throwable
     }
   }
 }

--- a/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
+++ b/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
@@ -37,7 +37,7 @@ object WeaponRegeXJS {
     *   mutationLevels: [Target mutation levels. If this is `null`, the `mutators` will not be filtered],
     * }
     * }}}
-    * @return A JavaScript Array of [[weaponregex.model.mutation.Mutant]]
+    * @return A JavaScript Array of [[weaponregex.model.mutation.Mutant]] if can be parsed, or throw an exception otherwise
     */
   @JSExportTopLevel("mutate")
   def mutate(pattern: String, options: MutationOptions = new MutationOptions()): js.Array[MutantJS] = {
@@ -51,9 +51,9 @@ object WeaponRegeXJS {
         options.mutationLevels.toSeq
       else null
 
-    (Parser(pattern) match {
-      case Some(tree) => tree.mutate(mutators, mutationLevels) map MutantJS
-      case None       => Nil
-    }).toJSArray
+    Parser(pattern) match {
+      case Success(tree)                        => (tree.mutate(mutators, mutationLevels) map MutantJS).toJSArray
+      case Failure(exception: RuntimeException) => throw exception
+    }
   }
 }

--- a/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
+++ b/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
@@ -8,6 +8,7 @@ import weaponregex.mutator.BuiltinMutators
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters._
 import scala.scalajs.js.annotation._
+import scala.util.{Failure, Success}
 
 /** The API facade of Weapon regeX for JavaScript
   * @note For JavaScript use only

--- a/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
+++ b/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
@@ -2,7 +2,6 @@ package weaponregex
 
 import weaponregex.mutator.BuiltinMutators
 import weaponregex.model.mutation.Mutant
-import scala.util.{Failure, Success, Try}
 
 class WeaponRegeXTest extends munit.FunSuite {
   test("Can mutate without options") {

--- a/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
+++ b/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
@@ -2,61 +2,74 @@ package weaponregex
 
 import weaponregex.mutator.BuiltinMutators
 import weaponregex.model.mutation.Mutant
+import scala.util.{Failure, Success, Try}
 
 class WeaponRegeXTest extends munit.FunSuite {
   test("Can mutate without options") {
-    val mutations = WeaponRegeX.mutate("^a")
+    val mutations = WeaponRegeX.mutate("^a").getOrElse(Nil)
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations.length, 2)
   }
 
   test("Can mutate with only mutators as option") {
-    val mutations = WeaponRegeX.mutate("^a", BuiltinMutators.all)
+    val mutations = WeaponRegeX.mutate("^a", BuiltinMutators.all).getOrElse(Nil)
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations.length, 2)
   }
 
   test("Can mutate with empty sequence of mutators as option") {
-    val mutations = WeaponRegeX.mutate("^a", Nil)
+    val mutations = WeaponRegeX.mutate("^a", Nil).getOrElse(Nil)
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations, Nil)
   }
 
   test("Can mutate with only levels as option") {
-    val mutations = WeaponRegeX.mutate("^a", mutationLevels = Seq(1))
+    val mutations = WeaponRegeX.mutate("^a", mutationLevels = Seq(1)).getOrElse(Nil)
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations.length, 1)
   }
 
   test("Can mutate with unsupported levels as option") {
-    val mutations = WeaponRegeX.mutate("^a", mutationLevels = Seq(100, 1000))
+    val mutations = WeaponRegeX.mutate("^a", mutationLevels = Seq(100, 1000)).getOrElse(Nil)
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations, Nil)
   }
 
   test("Can mutate with both mutators and levels as option") {
-    val mutations = WeaponRegeX.mutate("^a", BuiltinMutators.all, Seq(1))
+    val mutations = WeaponRegeX.mutate("^a", BuiltinMutators.all, Seq(1)).getOrElse(Nil)
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations.length, 1)
   }
 
   test("Returns an empty sequence if there are no mutants") {
-    val mutations = WeaponRegeX.mutate("a")
+    val mutations = WeaponRegeX.mutate("a").getOrElse(Nil)
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations, Nil)
   }
 
   test("Returns an empty sequence if the regex is invalid") {
-    val mutations = WeaponRegeX.mutate("*(a|$]")
+    val mutations = WeaponRegeX.mutate("*(a|$]").getOrElse(Nil)
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations, Nil)
+  }
+
+  test("Returns when Parser failed") {
+    val mutations = WeaponRegeX.mutate("(")
+
+    import scala.util.Failure
+    assert(clue(mutations) match {
+      case Failure(exception: RuntimeException) =>
+        println(exception.getMessage)
+        true
+      case _ => false
+    })
   }
 }

--- a/core/src/test/scala/weaponregex/mutator/MutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/MutatorTest.scala
@@ -15,7 +15,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Remove BOL") {
     val pattern = "^abc^def^"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(BOLRemoval))
     assertEquals(clue(mutants).length, 3)
@@ -30,7 +30,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Remove EOL") {
     val pattern = "$abc$def$"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(EOLRemoval))
     assertEquals(clue(mutants).length, 3)
@@ -45,7 +45,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Change BOL to BOI") {
     val pattern = "^abc^def^"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(BOL2BOI))
     assertEquals(clue(mutants).length, 3)
@@ -60,7 +60,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Change EOL to EOI") {
     val pattern = "$abc$def$"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(EOL2EOI))
     assertEquals(clue(mutants).length, 3)
@@ -75,7 +75,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Negate Predefined Character Class") {
     val pattern = """\w\W\d\D\s\S"""
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(PredefCharClassNegation))
     assertEquals(clue(mutants).length, 6)
@@ -93,7 +93,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Nullify Predefined Character Class") {
     val pattern = """\w\W\d\D\s\S"""
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(PredefCharClassNullification))
     assertEquals(clue(mutants).length, 6)
@@ -111,7 +111,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Predefined Character Class to Any Char") {
     val pattern = """\w\W\d\D\s\S"""
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(PredefCharClassAnyChar))
     assertEquals(clue(mutants).length, 6)
@@ -129,7 +129,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Character Class Negation") {
     val pattern = "[[abc][^abc]]"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(CharClassNegation))
     assertEquals(clue(mutants).length, 3)
@@ -144,7 +144,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Character Class Remove Child") {
     val pattern = "[ab0-9[A-Z][cd]]"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(CharClassChildRemoval))
     assertEquals(clue(mutants).length, 7)
@@ -163,7 +163,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Character Class to any char") {
     val pattern = "[abc[0-9]]"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(CharClassAnyChar))
     assertEquals(clue(mutants).length, 2)
@@ -177,7 +177,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [b-y][B-Y][1-8]") {
     val pattern = "[b-y][B-Y][1-8]"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(CharClassRangeModification))
     assertEquals(clue(mutants).length, 12)
@@ -204,7 +204,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [a-y][A-Y][0-8]") {
     val pattern = "[a-y][A-Y][0-8]"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(CharClassRangeModification))
     assertEquals(clue(mutants).length, 9)
@@ -228,7 +228,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [b-z][B-Z][1-9]") {
     val pattern = "[b-z][B-Z][1-9]"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(CharClassRangeModification))
     assertEquals(clue(mutants).length, 9)
@@ -252,7 +252,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [a-z][A-Z][0-9]") {
     val pattern = "[a-z][A-Z][0-9]"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(CharClassRangeModification))
     assertEquals(clue(mutants).length, 6)
@@ -273,7 +273,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [b-b][B-B][1-1]") {
     val pattern = "[b-b][B-B][1-1]"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(CharClassRangeModification))
     assertEquals(clue(mutants).length, 6)
@@ -294,7 +294,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [a-a][A-A][0-0]") {
     val pattern = "[a-a][A-A][0-0]"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(CharClassRangeModification))
     assertEquals(clue(mutants).length, 3)
@@ -312,7 +312,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [z-z][Z-Z][9-9]") {
     val pattern = "[z-z][Z-Z][9-9]"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(CharClassRangeModification))
     assertEquals(clue(mutants).length, 3)
@@ -330,7 +330,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Remove greedy quantifier") {
     val pattern = "a?b*c+d{1}e{1,}f{1,2}"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(QuantifierRemoval))
     assertEquals(clue(mutants).length, 6)
@@ -348,7 +348,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Remove reluctant quantifier") {
     val pattern = "a??b*?c+?d{1}?e{1,}?f{1,2}?"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(QuantifierRemoval))
     assertEquals(clue(mutants).length, 6)
@@ -366,7 +366,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Remove possessive quantifier") {
     val pattern = "a?+b*+c++d{1}+e{1,}+f{1,2}+"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(QuantifierRemoval))
     assertEquals(clue(mutants).length, 6)
@@ -384,7 +384,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Change quantifier {n}") {
     val pattern = "a{1}"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(QuantifierNChange))
     assertEquals(clue(mutants).length, 2)
@@ -398,7 +398,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Modify quantifier {n,}") {
     val pattern = "a{0,}b{1,}"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(QuantifierNOrMoreModification))
     assertEquals(clue(mutants).length, 3)
@@ -413,7 +413,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Change quantifier {n,}") {
     val pattern = "a{1,}"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(QuantifierNOrMoreChange))
     assertEquals(clue(mutants).length, 1)
@@ -424,7 +424,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Modify quantifier {n,m}") {
     val pattern = "a{0,0}b{0,1}c{1,2}"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(QuantifierNMModification))
     assertEquals(clue(mutants).length, 8)
@@ -444,7 +444,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Modify short quantifier") {
     val pattern = "a?b*c+"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(QuantifierShortModification))
     assertEquals(clue(mutants).length, 6)
@@ -462,7 +462,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Change short quantifier") {
     val pattern = "a*b+"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(QuantifierShortChange))
     assertEquals(clue(mutants).length, 2)
@@ -476,7 +476,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Add reluctant to greedy quantifier") {
     val pattern = "a?b*c+d{1}e{1,}f{1,2}"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(QuantifierReluctantAddition))
     assertEquals(clue(mutants).length, 6)
@@ -494,7 +494,7 @@ class MutatorTest extends munit.FunSuite {
 
   test("Change capturing group to non-capturing group") {
     val pattern = "(hello)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(GroupToNCGroup))
     assertEquals(clue(mutants).length, 1)

--- a/core/src/test/scala/weaponregex/parser/ParserTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserTest.scala
@@ -7,7 +7,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse concat of characters") {
     val pattern = "hello"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
     assert(clue(parsedTree).isInstanceOf[Concat])
 
     (pattern zip parsedTree.children) foreach { case (char, child) =>
@@ -22,7 +22,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse or of characters") {
     val pattern = "h|e|l|l|o"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
     assert(clue(parsedTree).isInstanceOf[Or])
 
     (pattern.replace("|", "") zip parsedTree.children) foreach { case (char, child) =>
@@ -37,7 +37,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse BOL and EOL") {
     val pattern = "^hello$"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
     assert(clue(parsedTree).isInstanceOf[Concat])
     assert(clue(parsedTree.children.head).isInstanceOf[BOL])
     assert(clue(parsedTree.children.last).isInstanceOf[EOL])
@@ -47,7 +47,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse boundary metacharacters") {
     val pattern = """\b\B\A\G\z\Z"""
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     (pattern.replace("""\""", "") zip parsedTree.children) foreach { case (char, child) =>
@@ -68,7 +68,7 @@ class ParserTest extends munit.FunSuite {
         |a
         |a
         |a""".stripMargin
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     ((parsedTree.children filter {
@@ -83,7 +83,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse positive character class with characters") {
     val pattern = "[abc]"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[CharacterClass])
     (pattern.init.tail zip parsedTree.children) foreach { case (char, child) =>
@@ -98,7 +98,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse negative character class with characters") {
     val pattern = "[^abc]"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(parsedTree match {
       case CharacterClass(_, _, false) => true
@@ -119,7 +119,7 @@ class ParserTest extends munit.FunSuite {
     val ranges = Seq("az", "AZ", "09")
     // Generate pattern from these ranges
     val pattern = "[" + ranges.map(r => r.head + "-" + r.last).mkString + "]"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[CharacterClass])
     (ranges zip parsedTree.children) foreach { case (range, child) =>
@@ -135,7 +135,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse character class with nested character classes") {
     val pattern = "[[a-z][^A-Z0-9][01234]]"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[CharacterClass])
     parsedTree.children foreach (child => assert(child.isInstanceOf[CharacterClass], clue = parsedTree.children))
@@ -145,7 +145,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse character class with predefined character classes") {
     val pattern = """[\w\W\s\S\d\D]"""
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[CharacterClass])
     (pattern.init.tail.replace("""\""", "") zip parsedTree.children) foreach { case (char, child) =>
@@ -160,7 +160,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse escape characters") {
     val pattern = """\\\t\n\r\f"""
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     // A backslash is added back in to represent the backslash in the pattern
@@ -176,7 +176,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse hexadecimal characters") {
     val pattern = "\\x20\\u0020\\x{000020}"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     (pattern.split("""\\""").tail zip parsedTree.children) foreach { case (str, child) =>
@@ -191,7 +191,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse octal characters") {
     val pattern = """\01\012\0123"""
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     (pattern.split("""\\""").tail zip parsedTree.children) foreach { case (str, child) =>
@@ -206,7 +206,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse predefined character class") {
     val pattern = """.\w\W\s\S\d\D"""
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     (pattern.replace("""\""", "") zip parsedTree.children) foreach { case (char, child) =>
@@ -222,7 +222,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse short greedy quantifiers") {
     val pattern = "a*b+c?"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     assert(clue(parsedTree.children(0)).isInstanceOf[ZeroOrMore])
@@ -243,7 +243,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse short reluctant quantifiers") {
     val pattern = "a*?b+?c??"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     assert(clue(parsedTree.children(0)).isInstanceOf[ZeroOrMore])
@@ -264,7 +264,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse short possessive quantifiers") {
     val pattern = "a*+b++c?+"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     assert(clue(parsedTree.children(0)).isInstanceOf[ZeroOrMore])
@@ -285,7 +285,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse long greedy quantifiers") {
     val pattern = "a{1}b{1,}c{1,2}"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
 
@@ -309,7 +309,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse long reluctant quantifiers") {
     val pattern = "a{1}?b{1,}?c{1,2}?"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
 
@@ -333,7 +333,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse long possessive quantifiers") {
     val pattern = "a{1}+b{1,}+c{1,2}+"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
 
@@ -357,7 +357,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse capturing group") {
     val pattern = "(hello)(world)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
 
@@ -376,7 +376,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse nested capturing group") {
     val pattern = "(hello(world))"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case Group(Concat(nodes, _), true, _) =>
@@ -393,7 +393,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse named capturing group") {
     val pattern = "(?<name1>hello)(?<name2>world)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     assert(clue(parsedTree.children(0)) match {
@@ -410,7 +410,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse nested named capturing group") {
     val pattern = "(?<name1>hello(?<name2>world))"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case NamedGroup(Concat(nodes, _), "name1", _) =>
@@ -427,7 +427,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse non-capturing group") {
     val pattern = "(?:hello)(?:world)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
 
@@ -446,7 +446,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse nested non-capturing group") {
     val pattern = "(?:hello(?:world))"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case Group(Concat(nodes, _), false, _) =>
@@ -463,7 +463,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse flag toggle group i-i") {
     val pattern = "(?idmsuxU-idmsuxU)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case FlagToggleGroup(FlagToggle(onFlags, true, offFlags, _), _) =>
@@ -476,7 +476,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse flag toggle group i-") {
     val pattern = "(?idmsuxU-)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case FlagToggleGroup(FlagToggle(onFlags, true, offFlags, _), _) =>
@@ -489,7 +489,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse flag toggle group -i") {
     val pattern = "(?-idmsuxU)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case FlagToggleGroup(FlagToggle(onFlags, true, offFlags, _), _) =>
@@ -502,7 +502,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse flag toggle group -") {
     val pattern = "(?-)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case FlagToggleGroup(FlagToggle(onFlags, true, offFlags, _), _) =>
@@ -515,7 +515,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse flag toggle group i") {
     val pattern = "(?idmsuxU)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case FlagToggleGroup(FlagToggle(onFlags, false, offFlags, _), _) =>
@@ -528,7 +528,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse non-capturing group with flags i-i") {
     val pattern = "(?idmsux-idmsux:hello)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case FlagNCGroup(FlagToggle(onFlags, true, offFlags, _), _: Concat, _) =>
@@ -541,7 +541,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse non-capturing group with flags i-") {
     val pattern = "(?idmsux-:hello)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case FlagNCGroup(FlagToggle(onFlags, true, offFlags, _), _: Concat, _) =>
@@ -554,7 +554,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse non-capturing group with flags -i") {
     val pattern = "(?-idmsux:hello)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case FlagNCGroup(FlagToggle(onFlags, true, offFlags, _), _: Concat, _) =>
@@ -567,7 +567,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse non-capturing group with flags -") {
     val pattern = "(?-:hello)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case FlagNCGroup(FlagToggle(onFlags, true, offFlags, _), _: Concat, _) =>
@@ -580,7 +580,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse non-capturing group with flags i") {
     val pattern = "(?idmsux:hello)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case FlagNCGroup(FlagToggle(onFlags, false, offFlags, _), _: Concat, _) =>
@@ -593,7 +593,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse positive lookahead") {
     val pattern = "(?=hello)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case Lookaround(_: Concat, true, true, _) => true
@@ -605,7 +605,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse negative lookahead") {
     val pattern = "(?!hello)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case Lookaround(_: Concat, false, true, _) => true
@@ -617,7 +617,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse positive lookbehind") {
     val pattern = "(?<=hello)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case Lookaround(_: Concat, true, false, _) => true
@@ -629,7 +629,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse negative lookbehind") {
     val pattern = "(?<!hello)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case Lookaround(_: Concat, false, false, _) => true
@@ -641,7 +641,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse independent non-capturing group") {
     val pattern = "(?>hello)"
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case INCGroup(_: Concat, _) => true
@@ -653,7 +653,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse named reference") {
     val pattern = """\k<name1>"""
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case NameReference("name1", _) => true
@@ -665,7 +665,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse numbered reference") {
     val pattern = """\123"""
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree) match {
       case NumberReference(123, _) => true
@@ -677,7 +677,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse character quote") {
     val pattern = """stuff\$hit"""
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     assert(clue(parsedTree.children(5)) match {
@@ -690,7 +690,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse long quote with end") {
     val pattern = """stuff\Q$hit\Emorestuff"""
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     assert(clue(parsedTree.children(5)) match {
@@ -703,7 +703,7 @@ class ParserTest extends munit.FunSuite {
 
   test("Parse long quote without end") {
     val pattern = """stuff\Q$hit"""
-    val parsedTree = Parser.parseOrError(pattern)
+    val parsedTree = Parser(pattern).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     assert(clue(parsedTree.children(5)) match {
@@ -712,5 +712,18 @@ class ParserTest extends munit.FunSuite {
     })
 
     treeBuildTest(parsedTree, pattern)
+  }
+
+  test("Parser failure") {
+    val pattern = "("
+    val parsedTree = Parser(pattern)
+
+    import scala.util.Failure
+    assert(clue(parsedTree) match {
+      case Failure(exception: RuntimeException) =>
+        println(exception.getMessage)
+        true
+      case _ => false
+    })
   }
 }

--- a/core/src/test/scala/weaponregex/parser/ParserTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserTest.scala
@@ -714,8 +714,21 @@ class ParserTest extends munit.FunSuite {
     treeBuildTest(parsedTree, pattern)
   }
 
-  test("Parser failure") {
+  test("Parser failure at start") {
     val pattern = "("
+    val parsedTree = Parser(pattern)
+
+    import scala.util.Failure
+    assert(clue(parsedTree) match {
+      case Failure(exception: RuntimeException) =>
+        println(exception.getMessage)
+        true
+      case _ => false
+    })
+  }
+
+  test("Parser failure mid-regex") {
+    val pattern = "abc(def"
     val parsedTree = Parser(pattern)
 
     import scala.util.Failure

--- a/node/test/api.js
+++ b/node/test/api.js
@@ -25,13 +25,19 @@ describe('Weapon regeX', function() {
     });
     
     it('Returns an empty array if there are no mutants', function() {
-      mutants = wrx.mutate('a');
+      let mutants = wrx.mutate('a');
       mocha.deepStrictEqual(mutants, []);
     });
     
-    it('Returns an empty array if the RegEx is invalid', function() {
-      mutants = wrx.mutate('*(a|$]');
-      mocha.deepStrictEqual(mutants, []);
+    it('Catch an exception if the RegEx is invalid', function() {
+      let failed = false;
+      try {
+        wrx.mutate('*(a|$]');
+      } catch(e) {
+        failed = true;
+        mocha.strictEqual(e.message.startsWith("[Error] Parser:"), true)
+      }
+      mocha.strictEqual(failed, true);
     });
   });
   
@@ -45,7 +51,7 @@ describe('Weapon regeX', function() {
     });
     
     it('Contains the mutator name', function() {
-        let mutants = wrx.mutate('^a', {mutationLevels: [1]});
+      let mutants = wrx.mutate('^a', {mutationLevels: [1]});
 
       mocha.strictEqual(mutants.length, 1);
       mocha.strictEqual(mutants[0].name, 'Beginning of line character `^` removal');


### PR DESCRIPTION
+ `Parser` now returns a `Success` of parsed `RegexTree` if can be parsed, a `Failure` otherwise
+ `WeaponRegeX` now returns a `Success` of a sequence of `Mutant` if can be parsed, a `Failure` otherwise
+ `WeaponRegeXJS` now returns a JavaScript Array of `Mutant` if can be parsed, or throw an exception otherwise
+ Update code to work with this
+ Update documentation
+ Add a test to check parse error for the `Parser`
+ Add a test to check parse error for the `WeaponRegeX` API

- Remove unused `parseOrError` in the `Parser`